### PR TITLE
Fix HLOOKUP row_index_num validation to use num rows

### DIFF
--- a/src/pycel/lib/lookup.py
+++ b/src/pycel/lib/lookup.py
@@ -171,7 +171,7 @@ def hlookup(lookup_value, table_array, row_index_num, range_lookup=True):
     if row_index_num <= 0:
         return VALUE_ERROR
 
-    if row_index_num > len(table_array[0]):
+    if row_index_num > len(table_array):
         return REF_ERROR
 
     result_idx = _match(

--- a/tests/lib/test_lookup.py
+++ b/tests/lib/test_lookup.py
@@ -68,12 +68,13 @@ def test_column(address, expected):
 
 
 @pytest.mark.parametrize(
-    'lkup, col_idx, result, approx', (
+    'lkup, row_idx, result, approx', (
         ('A', 0, VALUE_ERROR, True),
         ('A', 1, 'A', True),
         ('A', 2, 1, True),
         ('A', 3, 'Z', True),
-        ('A', 4, REF_ERROR, True),
+        ('A', 4, 5, True),
+        ('A', 5, REF_ERROR, True),
         ('B', 1, 'B', True),
         ('C', 1, 'C', True),
         ('B', 2, 2, True),
@@ -86,13 +87,14 @@ def test_column(address, expected):
         ((('D', 'A'),), 3, ((NA_ERROR, 'Z'), ), False),
     )
 )
-def test_hlookup(lkup, col_idx, result, approx):
+def test_hlookup(lkup, row_idx, result, approx):
     table = (
         ('A', 'B', 'C'),
         (1, 2, 3),
         ('Z', 'Y', 'X'),
+        (5, 6, 7),
     )
-    assert result == hlookup(lkup, table, col_idx, approx)
+    assert result == hlookup(lkup, table, row_idx, approx)
 
 
 @pytest.mark.parametrize(
@@ -491,7 +493,8 @@ def test_row(address, expected):
         ('A', 1, 'A', True),
         ('A', 2, 1, True),
         ('A', 3, 'Z', True),
-        ('A', 4, REF_ERROR, True),
+        ('A', 4, 5, True),
+        ('A', 5, REF_ERROR, True),
         ('B', 1, 'B', True),
         ('C', 1, 'C', True),
         ('B', 2, 2, True),
@@ -506,8 +509,8 @@ def test_row(address, expected):
 )
 def test_vlookup(lkup, col_idx, result, approx):
     table = (
-        ('A', 1, 'Z'),
-        ('B', 2, 'Y'),
-        ('C', 3, 'X'),
+        ('A', 1, 'Z', 5),
+        ('B', 2, 'Y', 6),
+        ('C', 3, 'X', 7),
     )
     assert result == vlookup(lkup, table, col_idx, approx)


### PR DESCRIPTION
Fixed a bug with HLOOKUP where it was validating the `row_index_num` against the number of columns instead of the number of rows in the table. Also adjusted the tests accordingly.

 - [ x ] tests added / passed
 - [ x ] passes ``tox``

