### PR TITLE
Enhance excel_helper to coerce values to arrays

### DIFF
--- a/src/pycel/excellib.py
+++ b/src/pycel/excellib.py
@@ -144,11 +144,10 @@ def count(*args):
                if isinstance(x, (int, float)) and not isinstance(x, bool))
 
 
+@excel_helper(err_str_params=None, array_params=0)
 def countif(rng, criteria):
     # Excel reference: https://support.office.com/en-us/article/
     #   COUNTIF-function-e0de10c6-f885-4e71-abb4-1f464816df34
-    if not list_like(rng):
-        rng = ((rng, ), )
     valid = find_corresponding_index(rng, criteria)
     return len(valid)
 

--- a/src/pycel/lib/function_helpers.py
+++ b/src/pycel/lib/function_helpers.py
@@ -270,8 +270,8 @@ def arrays_wrapper(f, param_indices=None):
     :param f: function to wrap
     :param param_indices: params to coerce to arrays.
         int: param number to check
-        tuple: params to check
-        None: check all params
+        tuple: params to convert
+        None: convert all params
     :return: wrapped function
     """
     param_indices = convert_params_indices(f, param_indices)

--- a/src/pycel/lib/lookup.py
+++ b/src/pycel/lib/lookup.py
@@ -297,7 +297,7 @@ def lookup(lookup_value, lookup_array, result_range=None):
         return match_idx
 
 
-@excel_helper(cse_params=0, number_params=2)
+@excel_helper(cse_params=0, number_params=2, array_params=1)
 def match(lookup_value, lookup_array, match_type=1):
     # Excel reference: https://support.office.com/en-us/article/
     #   match-function-e8dffd45-c762-47d6-bf89-533f4a37673a

--- a/tests/lib/test_function_helpers.py
+++ b/tests/lib/test_function_helpers.py
@@ -21,6 +21,7 @@ from pycel.excelutil import (
 )
 from pycel.lib.function_helpers import (
     apply_meta,
+    arrays_wrapper,
     cse_array_wrapper,
     error_string_wrapper,
     excel_helper,
@@ -67,6 +68,21 @@ def test_error_string_wrapper(arg_nums, f_args, result):
         return 'args: {}'.format(args)
 
     assert error_string_wrapper(f_test, arg_nums)(*f_args) == result
+
+
+@pytest.mark.parametrize(
+    'value, result', (
+        ((1, 2, 3), (1, ((2,),), 3)),
+        ((1, 'ab', 3), (1, (('ab',),), 3)),
+        ((1, ((2,),), 3), (1, ((2,),), 3)),
+        ((1, (1,), 3), (1, (1,), 3)),
+    )
+)
+def test_arrays_wrap(value, result):
+    def a_test(*args):
+        return args
+
+    assert arrays_wrapper(a_test, 1)(*value) == result
 
 
 @pytest.mark.parametrize(

--- a/tests/lib/test_function_helpers.py
+++ b/tests/lib/test_function_helpers.py
@@ -71,18 +71,19 @@ def test_error_string_wrapper(arg_nums, f_args, result):
 
 
 @pytest.mark.parametrize(
-    'value, result', (
-        ((1, 2, 3), (1, ((2,),), 3)),
-        ((1, 'ab', 3), (1, (('ab',),), 3)),
-        ((1, ((2,),), 3), (1, ((2,),), 3)),
-        ((1, (1,), 3), (1, (1,), 3)),
+    'arg_nums, f_args, result', (
+        (1, (1, 2, 3), (1, ((2,),), 3)),
+        ((1,), (1, 'ab', 3), (1, (('ab',),), 3)),
+        (None, (1, 2, 3), (((1,),), ((2,),), ((3,),))),
+        (0, (((1,),), 2, 3), (((1,),), 2, 3)),
+        (2, (1, 2, (3,)), (1, 2, (3,))),
     )
 )
-def test_arrays_wrap(value, result):
-    def a_test(*args):
+def test_arrays_wrapper(arg_nums, f_args, result):
+    def f_test(*args):
         return args
 
-    assert arrays_wrapper(a_test, 1)(*value) == result
+    assert arrays_wrapper(f_test, arg_nums)(*f_args) == result
 
 
 @pytest.mark.parametrize(

--- a/tests/lib/test_function_helpers.py
+++ b/tests/lib/test_function_helpers.py
@@ -77,6 +77,7 @@ def test_error_string_wrapper(arg_nums, f_args, result):
         (None, (1, 2, 3), (((1,),), ((2,),), ((3,),))),
         (0, (((1,),), 2, 3), (((1,),), 2, 3)),
         (2, (1, 2, (3,)), (1, 2, (3,))),
+        (2, (1, 2, VALUE_ERROR), (1, 2, ((VALUE_ERROR,),))),
     )
 )
 def test_arrays_wrapper(arg_nums, f_args, result):

--- a/tests/lib/test_lookup.py
+++ b/tests/lib/test_lookup.py
@@ -286,7 +286,10 @@ def test_lookup_error():
         (4, [1, 3.3, 5], 1, 2),
         (5, [1, 3.3, 5], 1, 3),
         (6, [1, 3.3, 5], 1, 3),
-
+        (6, 6, 1, 1),
+        (5, 6, 1, NA_ERROR),
+        ('abc', 'abc', 1, 1),
+        ('a', 'abc', 1, NA_ERROR),
         (6, [5, 3.3, 1], -1, NA_ERROR),
         (5, [5, 3.3, 1], -1, 1),
         (4, [5, 3.3, 1], -1, 1),
@@ -315,10 +318,13 @@ def test_lookup_error():
     )
 )
 def test_match(lookup_value, lookup_array, match_type, result):
-    lookup_row = (tuple(lookup_array), )
-    lookup_col = tuple((i, ) for i in lookup_array)
-    assert result == match(lookup_value, lookup_row, match_type)
-    assert result == match(lookup_value, lookup_col, match_type)
+    if isinstance(lookup_array, list):
+        lookup_row = (tuple(lookup_array), )
+        lookup_col = tuple((i, ) for i in lookup_array)
+        assert result == match(lookup_value, lookup_row, match_type)
+        assert result == match(lookup_value, lookup_col, match_type)
+    else:
+        assert result == match(lookup_value, lookup_array, match_type)
 
 
 @pytest.mark.parametrize(

--- a/tests/lib/test_lookup.py
+++ b/tests/lib/test_lookup.py
@@ -307,6 +307,8 @@ def test_lookup_error():
         (False, [True, False, True], -1, 2),
 
         (NA_ERROR, [True, False, True], -1, NA_ERROR),
+        (2, REF_ERROR, 1, NA_ERROR),
+        (REF_ERROR, REF_ERROR, 1, REF_ERROR),
         (DIV0, [1, 2, 3], -1, DIV0),
 
         ('Th*t', ['xyzzy', 1, False, DIV0, 'That', 'TheEnd'], 0, 5),

--- a/tests/test_excellib.py
+++ b/tests/test_excellib.py
@@ -267,6 +267,12 @@ def test_count():
         (((7, 25, 13, 25), ), 25, 2),
         (((7, 25, None, 25),), '<10', 1),
         (((7, 25, None, 25),), '>10', 2),
+        (((7, 25, None, 25),), NA_ERROR, 0),
+        (((7, 25, None, 25),), REF_ERROR, 0),
+        (NA_ERROR, '<10', 0),
+        (REF_ERROR, '<10', 0),
+        (NA_ERROR, NA_ERROR, 1),
+        (REF_ERROR, REF_ERROR, 1),
     )
 )
 def test_countif(value, criteria, result):


### PR DESCRIPTION
 - [ N/A ] closes #xxxx
 - [ x ] tests added / passed
 - [ x ] passes ``tox``

e.g. MATCH and COUNTIF support to get a value as a range. `=MATCH(BL51,BL370,0)` before this would return N/A. Now it will convert BL370 to an array (of size one) and carry on with the match