### PR TITLE
`conditional_format_ids` to return a tuple instead of a list

### DIFF
--- a/src/pycel/excellib.py
+++ b/src/pycel/excellib.py
@@ -164,7 +164,7 @@ def conditional_format_ids(*args):
             results.append(dxf_id)
             if stop_if_true:
                 break
-    return results
+    return tuple(results)
 
 
 def countifs(*args):

--- a/tests/test_excelcompiler.py
+++ b/tests/test_excelcompiler.py
@@ -490,7 +490,9 @@ def test_evaluate_conditional_formatting(cond_format_ws):
     ]
     formats = cond_format_ws.eval_conditional_formats(cells_addrs)
     formats2 = cond_format_ws.eval_conditional_formats((a for a in cells_addrs))
-    assert formats == list(formats2)
+    assert formats == list(formats2)  # should match cells_addrs's type
+    assert formats2 == tuple(formats2)  # tuple since cells_addrs is a generator
+    assert isinstance(formats[0], tuple)
     assert len(formats) == 3
     assert len(formats[2]) == 3
 

--- a/tests/test_excellib.py
+++ b/tests/test_excellib.py
@@ -228,12 +228,12 @@ class TestCeilingFloor:
 
 @pytest.mark.parametrize(
     'args, result', (
-        (((True, 1, 0), (True, 2, 1), (True, 3, 0)), [1, 2]),
-        (((False, 1, 0), (True, 2, 1), (True, 3, 0)), [2]),
-        (((False, 1, 0), (True, 2, 0), (True, 3, 0)), [2, 3]),
-        (((False, 1, 0), (False, 2, 0), (True, 3, 0)), [3]),
-        (((False, 1, 0), (False, 2, 0), (False, 3, 0)), []),
-        ((), []),
+        (((True, 1, 0), (True, 2, 1), (True, 3, 0)), (1, 2)),
+        (((False, 1, 0), (True, 2, 1), (True, 3, 0)), (2,)),
+        (((False, 1, 0), (True, 2, 0), (True, 3, 0)), (2, 3)),
+        (((False, 1, 0), (False, 2, 0), (True, 3, 0)), (3,)),
+        (((False, 1, 0), (False, 2, 0), (False, 3, 0)), ()),
+        ((), ()),
     )
 )
 def test_conditional_format_ids(args, result):


### PR DESCRIPTION
 - [ N/a ] closes #xxxx
 - [ x ] tests added / passed
 - [ x ] passes ``tox``

`conditional_format_ids` to return a tuple instead of a list. Tuple is the preferred choice when returning a collection. 

I ran in into an issue where the result of the `excel_formula.compiled_lambda()` was used to check if it matched one of the return codes, however `lists` are not hashable. Converting to tuple fixed my issue
https://github.com/dgorissen/pycel/blob/master/src/pycel/excelformula.py#L952