### PR TITLE
Handle calcPr missing in WorkbookPackage.

### DIFF
--- a/src/pycel/excelcompiler.py
+++ b/src/pycel/excelcompiler.py
@@ -92,7 +92,10 @@ class ExcelCompiler:
         # Setup to be able to evaluate circular references
         self.cycles = cycles
         if hasattr(self.excel, 'workbook'):
-            wb_cycles = bool(self.excel.workbook.calculation.iterate)
+            if self.excel.workbook.calculation is None:
+                wb_cycles = False
+            else:
+                wb_cycles = bool(self.excel.workbook.calculation.iterate)
             if self.cycles is None:
                 self.cycles = wb_cycles
             elif wb_cycles != bool(self.cycles):

--- a/tests/test_excelcompiler.py
+++ b/tests/test_excelcompiler.py
@@ -742,6 +742,11 @@ def test_validate_count():
     excel_compiler = ExcelCompiler(excel=wb)
     assert excel_compiler.evaluate('Sheet!B1:B4') == (1, 2, 3, 3)
 
+    # Test missing calcPr in WorkbookPackage
+    wb.calculation = None
+    excel_compiler = ExcelCompiler(excel=wb)
+    assert excel_compiler.evaluate('Sheet!B1:B4') == (1, 2, 3, 3)
+
 
 @pytest.mark.parametrize(
     'msg, formula', (


### PR DESCRIPTION
calculation property is overridden by the one of WorkbookPackage in openpyxl and may sometimes be set to `None` due to missing `<calcPr>`.

 - [x] closes #88
 - [x] tests added / passed
 - [x] passes ``tox``
