### PR TITLE
build_operator_operand_fixup throws #VALUE error when concatenating AddressCell objects

### DIFF
--- a/src/pycel/excelutil.py
+++ b/src/pycel/excelutil.py
@@ -1321,8 +1321,8 @@ def build_operator_operand_fixup(capture_error_state):
             right_op = coerce_to_number(right_op, convert_all=True)
 
             if not (is_number(left_op) and is_number(right_op) or
-                    isinstance(left_op, AddressRange) and
-                    isinstance(right_op, AddressRange)):
+                    isinstance(left_op, (AddressCell, AddressRange)) and
+                    isinstance(right_op, (AddressCell, AddressRange))):
                 if op != 'USub':
                     capture_error_state(
                         True, 'Values: {} {} {}'.format(left_op, op, right_op))


### PR DESCRIPTION
The purpose of the proposed change is to be able to concatenate ranges of type AddressCell via the ':' operator. This is because _REF_ (= AddressRange.create) may return objects of type AddressCell, not just AddressRange.

