### PR TITLE
Make prefix unary operators right-associative

### DIFF
--- a/src/pycel/excelformula.py
+++ b/src/pycel/excelformula.py
@@ -134,7 +134,7 @@ class Token(tokenizer.Token):
         ':': Precedence(8, 'left'),
         ' ': Precedence(8, 'left'),  # range intersection
         ',': Precedence(8, 'left'),
-        'u': Precedence(7, 'left'),  # unary operator
+        'u': Precedence(7, 'right'),  # unary operator
         '%': Precedence(6, 'left'),
         '^': Precedence(5, 'left'),
         '*': Precedence(4, 'left'),

--- a/tests/test_excelformula.py
+++ b/tests/test_excelformula.py
@@ -570,7 +570,6 @@ def test_if_args_error():
         '=;',
         '=,',
         '=-',
-        '=--4',
     )
 )
 def test_parser_error(formula):

--- a/tests/test_excelformula.py
+++ b/tests/test_excelformula.py
@@ -189,6 +189,11 @@ basic_inputs = [
         '=OR(TRUE, TRUE(), FALSE, FALSE())',
         'TRUE|TRUE|FALSE|FALSE|OR',
         'x_or(True, True, False, False)'),
+    FormulaTest(
+        '=--4',
+        '4|-|-',
+        '--4'
+    ),
 ]
 
 whitespace_inputs = [


### PR DESCRIPTION
Closes https://github.com/dgorissen/pycel/issues/105
 - [x] closes https://github.com/dgorissen/pycel/issues/105
 - [x] tests added / passed
 - [ ] passes ``tox``

Passes all tests in [test_excelformula.py](https://github.com/dgorissen/pycel/pull/106/files#diff-3e1cf2b3cb6006d8bdb12b24d05bdbaf66e480eee17cddfed6fa050e249e1cf5). Several other tests are not passed but they were not working originally either.