### PR TITLE
always clear range todos so that evaluation after error is stable

### DIFF
--- a/src/pycel/excelcompiler.py
+++ b/src/pycel/excelcompiler.py
@@ -943,9 +943,11 @@ class ExcelCompiler:
                     self.cell_map[precedent_address.address], dependant)
 
         # calc the values for ranges
-        for range_todo in reversed(self.range_todos):
-            self._evaluate_range(range_todo)
-        self.range_todos = []
+        try:
+            for range_todo in reversed(self.range_todos):
+                self._evaluate_range(range_todo)
+        finally:
+            self.range_todos = []
 
         self.log.info(
             f"Graph construction done, {len(self.dep_graph.nodes())} nodes, "


### PR DESCRIPTION
 - [x] closes #128 
 - [x] tests passed
 - [x] passes ``tox``

I just wrapped the evaluation of the ranges in `range_todos` in the function `_process_gen_graph` in a try/finally. In the finally statement we clear `range_todos` so that if we can't evaluate some range, it doesn't get trapped in `range_todos` forever. Previously, the range with the error would remain there, so every time you'd try to evaluate a cell that wasn't in the `cell_map` you'd error out the first time evaluate was called. This hopefully makes the order of evaluation irrelevant. 

If you prefer the warning solution still, let me know. We could alternatively log a warning here, but I figured a complete solution would be nicer... 

I haven't added any tests - would be happy to add some if you think it's necessary! It resolves my example in #128 at least. Could have test that compares 1) the values of evaluated cells before one attempts to evaluate an unimplemented function and 2) the values afterwards, as a sanity check. 

