### PR TITLE
account for trivial case in sumproduct

### DIFF
--- a/src/pycel/excellib.py
+++ b/src/pycel/excellib.py
@@ -360,9 +360,16 @@ def sumproduct(*args):
     if error:
         return error
 
+    if all(not isinstance(arg, tuple) for arg in args):
+        values = np.array([x if isinstance(x, (float, int))
+                                and not isinstance(x, bool) else 0 for x in args])
+        return np.prod(values)
+
     # verify array sizes match
     sizes = set()
     for arg in args:
+        if not isinstance(arg, tuple):
+            return VALUE_ERROR
         assert is_array_arg(arg)
         sizes.add((len(arg), len(arg[0])))
     if len(sizes) != 1:

--- a/tests/test_excellib.py
+++ b/tests/test_excellib.py
@@ -482,6 +482,8 @@ def test_sumifs(data, result):
 
 @pytest.mark.parametrize(
     'args, result', (
+        ((1, 2, 3, 4), 24),
+        ((1, 2, 3, True), 0),
         ((((1, 2), (3, 4)), ((1, 3), (2, 4))), 29),
         ((((3, 4), (8, 6), (1, 9)), ((2, 7), (6, 7), (5, 3))), 156),
         ((((1, 2), (3, None)), ((1, 3), (2, 4))), 13),
@@ -490,6 +492,7 @@ def test_sumifs(data, result):
         ((((1, NAME_ERROR), (3, 4)), ((1, 3), (2, 4))), NAME_ERROR),
         ((((1, 2), (3, 4)), ((1, 3), (NAME_ERROR, 4))), NAME_ERROR),
         ((((1, 2, 3), (3, 4, 6)), ((1, 3), (2, 4))), VALUE_ERROR),
+        ((((1, 2, 3),), ((1, 2, 3),), 5), VALUE_ERROR),
     )
 )
 def test_sumproduct(args, result):


### PR DESCRIPTION
 - [x] tests added / passed
 - [ ] passes ``tox`` (Didn't check this time, having a pyenv bug with Big Sur... need to figure that out... )

I was hoping to change sumproduct to have it account for the trivial usage (i.e., just multiplication). Right now, if you try to use it like eg, =SUMPRODUCT(A1, B1, C1) - this gives an AssertionError, but Excel does evaluate it. Maybe there's a better way to implement this change.