### PR TITLE
fix order of evaluation test

### DIFF
--- a/tests/test_excelcompiler.py
+++ b/tests/test_excelcompiler.py
@@ -23,7 +23,7 @@ from openpyxl.workbook.defined_name import DefinedName
 from ruamel.yaml import YAML
 
 from pycel.excelcompiler import _Cell, _CellRange, ExcelCompiler, Mismatch
-from pycel.excelformula import FormulaEvalError, FormulaParserError, UnknownFunction
+from pycel.excelformula import FormulaParserError, UnknownFunction
 from pycel.excelutil import (
     AddressCell,
     AddressRange,
@@ -1117,8 +1117,10 @@ def test_evaluate_after_range_eval_error():
     ws = wb.active
     ws['A1'], ws['B1'], ws['C1'] = 0, 1, 0
     ws['A2'] = '=UNKNOWN(A1:C1,0,FALSE,1,TRUE)'
+    ws.formula_attributes['A2'] = {'t': 'array', 'ref': "A2:C2"}
     ws['A3'] = 'hello'
     ws['A4'] = '=UNKNOWN(A1:C1,1,FALSE,0,TRUE)'
+    ws.formula_attributes['A4'] = {'t': 'array', 'ref': "A4:C4"}
     ws['A5'] = '=AND(A2,A4)'
 
     excel_compiler = ExcelCompiler(excel=wb)
@@ -1127,6 +1129,6 @@ def test_evaluate_after_range_eval_error():
     assert excel_compiler.evaluate('A3') == 'hello'
 
     excel_compiler = ExcelCompiler(excel=wb)
-    with pytest.raises(FormulaEvalError):
+    with pytest.raises(UnknownFunction):
         excel_compiler.evaluate('A5')
     assert excel_compiler.evaluate('A3') == 'hello'


### PR DESCRIPTION
Sorry to bother you again with this... but I just realized the test I wrote didn't actually do what we wanted because I didn't set `ws.formula_attributes`! That means the test would have passed even without the fix. Now it should be good though. (Without the changes, the first assertion would have failed, and with the while loop/pop solution you proposed, the second assertion would have failed.)

I also figured there's no reason to make this test dependent on the switch function being unimplemented. 
