### PR TITLE
accounting for white spaces in ranges

### DIFF
--- a/tests/test_excelformula.py
+++ b/tests/test_excelformula.py
@@ -68,6 +68,34 @@ range_inputs = [
         'B5:B15|A7:D7| |SUM',
         'sum_(_R_(str(_REF_("B5:B15") & _REF_("A7:D7"))))'),
     FormulaTest(
+        '=SUM( sheet1!A1:A2)',
+        'sheet1!A1:A2|SUM',
+        'sum_(_R_("sheet1!A1:A2"))'),
+    FormulaTest(
+        '=SUM(sheet1!A1:A2 )',
+        'sheet1!A1:A2|SUM',
+        'sum_(_R_("sheet1!A1:A2"))'),
+    FormulaTest(
+        '=SUM(sheet1! A1:A2)',
+        'sheet1!A1:A2|SUM',
+        'sum_(_R_("sheet1!A1:A2"))'),
+    FormulaTest(
+        '=SUM(sheet1 !A1:A2)',
+        'sheet1!A1:A2|SUM',
+        'sum_(_R_("sheet1!A1:A2"))'),
+    FormulaTest(
+        '=SUM(sheet1!A1 :A2)',
+        'sheet1!A1:A2|SUM',
+        'sum_(_R_("sheet1!A1:A2"))'),
+    FormulaTest(
+        '=SUM(sheet1!A1: A2)',
+        'sheet1!A1:A2|SUM',
+        'sum_(_R_("sheet1!A1:A2"))'),
+    FormulaTest(
+        '=SUM(sheet1!A1 : A2)',
+        'sheet1!A1:A2|SUM',
+        'sum_(_R_("sheet1!A1:A2"))'),
+    FormulaTest(
         '=SUM((A:A,1:1))',
         'A:A|1:1|,|SUM',
         'sum_(_R_("A:A"), _R_("1:1"))'),


### PR DESCRIPTION
 - [x] closes #136
 - [x] tests added / passed
 - [x] passes ``tox``

Previously, we had the following behavior for variations of `'=SUM(Sheet2!A1:A2)'`:
```python
from openpyxl import Workbook
wb = Workbook()
wb.create_sheet('Sheet1')
wb.create_sheet('Sheet2')
ws = wb['Sheet2']
ws['A1'], ws['A2'] = 1, 2

ws = wb['Sheet1']
ws['A1'] = f'=SUM(\'Sheet2\' !A1:A2)'    # FAILED - this one is a syntax error in Excel too, but you're prompted to correct it
ws['A2'] = f'=SUM(\'Sheet2\'! A1:A2)'    # #NAME?
ws['A3'] = f'=SUM(\'Sheet2\'!A1 :A2)'    # FAILED
ws['A4'] = f'=SUM(\'Sheet2\'!A1: A2)'    # #NAME?
ws['A5'] = f'=SUM(\'Sheet2\'!A1 : A2)'   # FAILED
```

Now these should all work (i.e., evaluate to 3). They'll also work with multiple whitespaces because the openpyxl tokenizer tokenizes it the same way. 

I had to add the `any(c in '!:' for c in (last_token.value[-1], next_token.value[0])` condition because without it other tests fail - like this possibility `'=SUM((A:A A1:B1))'`