### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/pycel/excelcompiler.py
+++ b/src/pycel/excelcompiler.py
@@ -417,7 +417,7 @@ class ExcelCompiler:
         :param value: value to set.  This can be a value or a tuple/list
             which matches the shapes needed for the given address/addresses
         :param set_as_range: With a single range address and a list like value,
-            set to true to set the entire rnage to the inserted list.
+            set to true to set the entire range to the inserted list.
         """
 
         if list_like(value) and not set_as_range:

--- a/tests/test_excelutil.py
+++ b/tests/test_excelutil.py
@@ -1139,7 +1139,7 @@ def test_excel_cmp(lval, op, rval, expected):
         ('X', 'BitAnd', 5.0, 'X5'),
         ('X', 'BitAnd', 5.0, 'X5'),
 
-        # divsion by zero
+        # division by zero
         (DIV0, '', '', DIV0),
         ('', '', DIV0, DIV0),
 


### PR DESCRIPTION
There are small typos in:
- src/pycel/excelcompiler.py
- tests/test_excelutil.py

Fixes:
- Should read `range` rather than `rnage`.
- Should read `division` rather than `divsion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md