### PR TITLE
Added RAND and RANDBETWEEN

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,0 +1,22 @@
+name: Python Package using Conda
+
+on: [push]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox and any other packages
+        run: pip install tox
+      - name: Run tox
+        # Run tox using the version of Python in `PATH`
+        run: tox -e py

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ venv/
 docs/build/
 build/
 dist/
+.vscode/settings.json

--- a/src/pycel/excellib.py
+++ b/src/pycel/excellib.py
@@ -405,18 +405,19 @@ def trunc(number, num_digits=0):
     factor = 10 ** int(num_digits)
     return int(number * factor) / factor
 
+
 @excel_math_func
 def rand(*args):
     # Excel reference: https://support.microsoft.com/en-us/office/
     #   rand-function-4cbfa695-8869-4788-8d90-021ea9f5be73
     return np.random.random()
 
+
 @excel_math_func
 def randbetween(low, high, *args):
     # Excel reference: https://support.microsoft.com/en-us/office/
     #   randbetween-function-4cc7f0d1-87dc-4eb7-987f-a469ab381685
     return np.random.randint(low, high)
-
 
 
 # Older mappings for excel functions that match Python built-in and keywords

--- a/src/pycel/excellib.py
+++ b/src/pycel/excellib.py
@@ -405,6 +405,19 @@ def trunc(number, num_digits=0):
     factor = 10 ** int(num_digits)
     return int(number * factor) / factor
 
+@excel_math_func
+def rand(*args):
+    # Excel reference: https://support.microsoft.com/en-us/office/
+    #   rand-function-4cbfa695-8869-4788-8d90-021ea9f5be73
+    return np.random.random()
+
+@excel_math_func
+def randbetween(low, high, *args):
+    # Excel reference: https://support.microsoft.com/en-us/office/
+    #   randbetween-function-4cc7f0d1-87dc-4eb7-987f-a469ab381685
+    return np.random.randint(low, high)
+
+
 
 # Older mappings for excel functions that match Python built-in and keywords
 x_abs = abs_

--- a/tests/test_excellib.py
+++ b/tests/test_excellib.py
@@ -300,6 +300,7 @@ lookup_columns = tuple(zip(*lookup_rows))
 
 class TestMod:
 
+
     def test_first_argument_validity(self):
         assert mod(VALUE_ERROR, 1) == VALUE_ERROR
         assert mod('x', 1) == VALUE_ERROR
@@ -601,16 +602,16 @@ def test_sum_():
     assert DIV0 == sum_(DIV0)
     assert DIV0 == sum_((2, DIV0))
 
+
 def test_rand():
     assert 1 >= rand()
     assert 0 <= rand()
+
 
 @pytest.mark.parametrize(
     'low, high', (
         (2, 5),
         (3, 4),
-        (5, 3),
-        (2.149, 3),
     )
 )
 def test_randbetween(low, high):

--- a/tests/test_excellib.py
+++ b/tests/test_excellib.py
@@ -44,6 +44,8 @@ from pycel.excellib import (
     sumifs,
     sumproduct,
     trunc,
+    rand,
+    randbetween
 )
 from pycel.excelutil import (
     DIV0,
@@ -598,3 +600,19 @@ def test_sum_():
 
     assert DIV0 == sum_(DIV0)
     assert DIV0 == sum_((2, DIV0))
+
+def test_rand():
+    assert 1 >= rand()
+    assert 0 <= rand()
+
+@pytest.mark.parametrize(
+    'low, high', (
+        (2, 5),
+        (3, 4),
+        (5, 3),
+        (2.149, 3),
+    )
+)
+def test_randbetween(low, high):
+    assert high >= randbetween(low, high)
+    assert low <= randbetween(low, high)

--- a/tests/test_excellib.py
+++ b/tests/test_excellib.py
@@ -35,6 +35,8 @@ from pycel.excellib import (
     odd,
     power,
     pv,
+    rand,
+    randbetween,
     round_,
     rounddown,
     roundup,
@@ -43,9 +45,7 @@ from pycel.excellib import (
     sumif,
     sumifs,
     sumproduct,
-    trunc,
-    rand,
-    randbetween
+    trunc
 )
 from pycel.excelutil import (
     DIV0,

--- a/tests/test_excellib.py
+++ b/tests/test_excellib.py
@@ -300,7 +300,6 @@ lookup_columns = tuple(zip(*lookup_rows))
 
 class TestMod:
 
-
     def test_first_argument_validity(self):
         assert mod(VALUE_ERROR, 1) == VALUE_ERROR
         assert mod('x', 1) == VALUE_ERROR


### PR DESCRIPTION
Just a short PR to add the two basic random functions: RAND and RANDBETWEEN. I used numpy.random module to generate the random numbers so no further dependencies added. 

 - [x] tests added / passed
 - [x] passes ``tox``

