### PR TITLE
Python 3.14 compatibility patch and other dependant upstream package updates

### DIFF
--- a/src/pycel/__init__.py
+++ b/src/pycel/__init__.py
@@ -1,3 +1,25 @@
+def _install_openpyxl_compat():
+    # openpyxl 3.1 removed .append on DefinedNameDict
+    try:
+        from openpyxl.workbook.defined_name import DefinedNameDict
+        if not hasattr(DefinedNameDict, 'append'):
+            DefinedNameDict.append = lambda self, value: self.add(value)
+    except Exception:  # pragma: no cover
+        pass
+
+    # openpyxl 3.1 removed Worksheet.formula_attributes
+    try:
+        from openpyxl.worksheet.worksheet import Worksheet
+        if not hasattr(Worksheet, 'formula_attributes'):
+            def _formula_attributes(self):
+                return self.__dict__.setdefault('_pycel_formula_attributes', {})
+            Worksheet.formula_attributes = property(_formula_attributes)
+    except Exception:  # pragma: no cover
+        pass
+
+
+_install_openpyxl_compat()
+
 from .excelcompiler import ExcelCompiler
 from .excelutil import AddressCell, AddressRange, PyCelException
 from .version import __version__

--- a/src/pycel/__init__.py
+++ b/src/pycel/__init__.py
@@ -2,7 +2,7 @@ def _install_openpyxl_compat():
     # openpyxl 3.1 removed .append on DefinedNameDict
     try:
         from openpyxl.workbook.defined_name import DefinedNameDict
-        if not hasattr(DefinedNameDict, 'append'):
+        if not hasattr(DefinedNameDict, 'append'):  # pragma: no branch
             DefinedNameDict.append = lambda self, value: self.add(value)
     except Exception:  # pragma: no cover
         pass
@@ -10,7 +10,7 @@ def _install_openpyxl_compat():
     # openpyxl 3.1 removed Worksheet.formula_attributes
     try:
         from openpyxl.worksheet.worksheet import Worksheet
-        if not hasattr(Worksheet, 'formula_attributes'):
+        if not hasattr(Worksheet, 'formula_attributes'):  # pragma: no branch
             def _formula_attributes(self):
                 return self.__dict__.setdefault('_pycel_formula_attributes', {})
             Worksheet.formula_attributes = property(_formula_attributes)
@@ -20,6 +20,8 @@ def _install_openpyxl_compat():
 
 _install_openpyxl_compat()
 
-from .excelcompiler import ExcelCompiler
-from .excelutil import AddressCell, AddressRange, PyCelException
-from .version import __version__
+# Imports are intentionally after compatibility patching, so pycel users get
+# openpyxl shims installed as soon as the package is imported.
+from .excelcompiler import ExcelCompiler  # noqa: E402
+from .excelutil import AddressCell, AddressRange, PyCelException  # noqa: E402
+from .version import __version__  # noqa: E402

--- a/src/pycel/excelcompiler.py
+++ b/src/pycel/excelcompiler.py
@@ -392,6 +392,11 @@ class ExcelCompiler:
         write_dot(self.dep_graph, filename)
 
     def export_to_gexf(self, filename=None):
+        # networkx<2.7 still references np.float_, removed in numpy 2.x
+        import numpy as np
+        if not hasattr(np, 'float_'):  # pragma: no cover
+            np.float_ = np.float64
+
         from networkx.readwrite.gexf import write_gexf
         filename = filename or (self.filename + '.gexf')
         write_gexf(self.dep_graph, filename)

--- a/src/pycel/excelformula.py
+++ b/src/pycel/excelformula.py
@@ -986,13 +986,13 @@ class ExcelFormula:
             def visit_UnaryOp(self, node):
                 """ change the UnaryOp node to a function node """
                 node = ast.NodeTransformer.generic_visit(self, node)
-                left = ast.Str(EMPTY)
+                left = ast.Constant(value=EMPTY)
                 return self.replace_op(node, left, node.op, node.operand)
 
             def replace_op(self, node, left, node_op, right):
                 """ change the compare node to a function node """
 
-                op = ast.Str(s=type(node_op).__name__)
+                op = ast.Constant(value=type(node_op).__name__)
                 return ast.Call(
                     func=ast.Name(id='excel_operator_operand_fixup',
                                   ctx=ast.Load()),

--- a/src/pycel/excelformula.py
+++ b/src/pycel/excelformula.py
@@ -852,7 +852,11 @@ class ExcelFormula:
         def capture_error_state(is_exception, msg):
             if is_exception:
                 import traceback
-                trace = traceback.format_exc()
+                exc_type, exc_value, exc_tb = sys.exc_info()
+                summary = traceback.extract_tb(exc_tb) if exc_tb else ()
+                frame_line = summary[-1].line if summary and summary[-1].line else ''
+                exc_only = ''.join(traceback.format_exception_only(exc_type, exc_value))
+                trace = f'{frame_line}\n{exc_only}'
             else:
                 trace = ''  # pragma: no cover
             error_messages.append((trace, msg))

--- a/src/pycel/excelformula.py
+++ b/src/pycel/excelformula.py
@@ -854,9 +854,15 @@ class ExcelFormula:
                 import traceback
                 exc_type, exc_value, exc_tb = sys.exc_info()
                 summary = traceback.extract_tb(exc_tb) if exc_tb else ()
-                frame_line = summary[-1].line if summary and summary[-1].line else ''
+                trace_lines = []
+                for frame in summary:
+                    trace_lines.append(
+                        f'File "{frame.filename}", line {frame.lineno}, in {frame.name}')
+                    if frame.line:
+                        trace_lines.append(frame.line.strip())
                 exc_only = ''.join(traceback.format_exception_only(exc_type, exc_value))
-                trace = f'{frame_line}\n{exc_only}'
+                trace_lines.append(exc_only.strip())
+                trace = '\n'.join(trace_lines) + '\n'
             else:
                 trace = ''  # pragma: no cover
             error_messages.append((trace, msg))

--- a/src/pycel/excelwrapper.py
+++ b/src/pycel/excelwrapper.py
@@ -289,7 +289,7 @@ class ExcelOpxWrapper(ExcelWrapper):
                     continue
 
                 ref_addr = AddressRange(props.get('ref'))
-                if isinstance(ref_addr, AddressRange):
+                if isinstance(ref_addr, AddressRange):  # pragma: no branch
                     formula = ws[address].value
                     for i, row in enumerate(ref_addr.rows, start=1):
                         for j, addr in enumerate(row, start=1):

--- a/src/pycel/excelwrapper.py
+++ b/src/pycel/excelwrapper.py
@@ -282,6 +282,20 @@ class ExcelOpxWrapper(ExcelWrapper):
                     # consider using the new behavior.
                     ws[ref_addr.coordinate] = ws[ref_addr.coordinate].value.text
 
+            # compatibility for workbooks that still set legacy
+            # worksheet.formula_attributes directly
+            for address, props in getattr(ws, 'formula_attributes', {}).items():
+                if address in ws.array_formulae or props.get('t') != 'array':
+                    continue
+
+                ref_addr = AddressRange(props.get('ref'))
+                if isinstance(ref_addr, AddressRange):
+                    formula = ws[address].value
+                    for i, row in enumerate(ref_addr.rows, start=1):
+                        for j, addr in enumerate(row, start=1):
+                            ws[addr.coordinate] = ARRAY_FORMULA_FORMAT % (
+                                formula[1:], i, j, *ref_addr.size)
+
     def old_load_array_formulas(self):  # pragma: no cover
         """expand array formulas"""
         # formula_attributes was dropped in openpyxl 3.0.8

--- a/src/pycel/excelwrapper.py
+++ b/src/pycel/excelwrapper.py
@@ -168,8 +168,13 @@ class ExcelOpxWrapper(ExcelWrapper):
     def defined_names(self):
         if self.workbook is not None and self._defined_names is None:
             self._defined_names = {}
+            source = self.workbook.defined_names
+            if hasattr(source, 'definedName'):
+                names = source.definedName
+            else:
+                names = source.values()
 
-            for d_name in self.workbook.defined_names.definedName:
+            for d_name in names:
                 destinations = [
                     (alias, wksht) for wksht, alias in d_name.destinations
                     if wksht in self.workbook]
@@ -219,7 +224,8 @@ class ExcelOpxWrapper(ExcelWrapper):
         formats = (cf for cf in all_formats if address.coordinate in cf)
         rules = []
         for cf in formats:
-            origin = AddressRange(cf.cells.ranges[0].coord).start
+            first_range = next(iter(cf.cells.ranges))
+            origin = AddressRange(first_range.coord).start
             row_offset = address.row - origin.row
             col_offset = address.col_idx - origin.col_idx
             for rule in cf.rules:

--- a/src/pycel/lib/function_helpers.py
+++ b/src/pycel/lib/function_helpers.py
@@ -221,7 +221,7 @@ def nums_wrapper(f, param_indices=None):
         try:
             return f(*new_args)
         except ValueError as exc:
-            if "math domain error" in str(exc):
+            if "math domain error" in str(exc) or "expected a positive input" in str(exc):
                 return NUM_ERROR
             raise  # pragma: no cover
 

--- a/tests/test_excelwrapper.py
+++ b/tests/test_excelwrapper.py
@@ -13,8 +13,38 @@ from pycel.excelutil import AddressRange
 from pycel.excelwrapper import (
     _OpxRange,
     ARRAY_FORMULA_FORMAT,
+    ExcelOpxWrapper,
     ExcelOpxWrapperNoData,
 )
+
+
+def test_get_defined_names_legacy_openpyxl_api():
+    class FakeDefinedName:
+        name = 'LEGACY'
+        destinations = (('Sheet1', '$A$1:$A$2'),)
+
+    class FakeDefinedNames:
+        definedName = (FakeDefinedName(),)
+
+    class FakeWorkbook:
+        defined_names = FakeDefinedNames()
+
+        def __contains__(self, item):
+            return item == 'Sheet1'
+
+    excel = ExcelOpxWrapper('ignored.xlsx')
+    excel.workbook = FakeWorkbook()
+    assert {'LEGACY': [('$A$1:$A$2', 'Sheet1')]} == excel.defined_names
+
+
+def test_load_array_formulas_skips_non_array_formula_attributes():
+    class FakeWorksheet:
+        array_formulae = {}
+        formula_attributes = {'A1': {'t': 'shared', 'ref': 'A1'}}
+
+    excel = ExcelOpxWrapper('ignored.xlsx')
+    excel.workbook = (FakeWorksheet(),)
+    excel.load_array_formulas()
 
 
 def test_set_and_get_active_sheet(excel):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -9,12 +9,12 @@
 
 import os
 import sys
-from packaging.version import Version
 from pathlib import Path
 from unittest import mock
 
 import pytest
 import restructuredtext_lint
+from packaging.version import Version
 
 import pycel
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -8,7 +8,7 @@
 #   https://www.gnu.org/licenses/gpl-3.0.en.html
 
 import os
-from distutils.version import LooseVersion
+from packaging.version import Version
 from pathlib import Path
 from unittest import mock
 
@@ -42,9 +42,17 @@ def test_module_version():
 
 
 def test_module_version_components():
-    loose = LooseVersion(pycel.__version__).version
-    for component in loose:
-        assert isinstance(component, int) or component in ('a', 'b', 'rc')
+    v = Version(pycel.__version__)
+
+    # Release segment: always ints, e.g. (1, 2, 3)
+    for n in v.release:
+        assert isinstance(n, int)
+
+    # Optional pre-release segment: ('a'|'b'|'rc', int), e.g. ('rc', 1)
+    if v.pre is not None:
+        tag, num = v.pre
+        assert tag in ("a", "b", "rc")
+        assert isinstance(num, int)
 
 
 def test_docs_versions(changes_rst):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -8,6 +8,7 @@
 #   https://www.gnu.org/licenses/gpl-3.0.en.html
 
 import os
+import sys
 from packaging.version import Version
 from pathlib import Path
 from unittest import mock
@@ -31,10 +32,16 @@ def setup_py():
     with mock.patch('setuptools.setup'), mock.patch('setuptools.find_packages'):
         cwd = os.getcwd()
         os.chdir(repo_root)
-        import importlib
-        setup = importlib.import_module('setup')
-        os.chdir(cwd)
-        return setup
+        sys.path.insert(0, str(repo_root))
+        try:
+            import importlib.util
+            spec = importlib.util.spec_from_file_location('setup', repo_root / 'setup.py')
+            setup = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(setup)
+            return setup
+        finally:
+            sys.path.pop(0)
+            os.chdir(cwd)
 
 
 def test_module_version():
@@ -69,7 +76,7 @@ def test_docs_versions(changes_rst):
     assert pycel.version.__version__ == doc_versions[1][1:-1]
 
     for v1, v2 in zip(doc_versions[1:], doc_versions[2:]):
-        assert LooseVersion(v1[1:-1]) > LooseVersion(v2[1:-1])
+        assert Version(v1[1:-1]) > Version(v2[1:-1])
 
 
 def test_binder_requirements(setup_py):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py310, py311, py312, py313, py314
+envlist = py36, py37, py38, py39, py310, py311, py312, py313, py314
 
 [testenv]
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, py39, py310
+envlist = py310, py311, py312, py313, py314
 
 [testenv]
 


### PR DESCRIPTION
 - [x] closes #167
 - [x] tests added / passed
 - [x] passes ``tox``

Changes:

- Replace `ast.Str` to `ast.Constant`
- Replace `distutils.version.LooseVersion` to `packaging.version.Version`
- Allow the newer error message "expected a positive input" on top of the old "math domain error"
- Add compatibility for openpyxl 3.1
- Add compatibility for NumPy 2
- Normalize exception-log formatting across Python versions while preserving file/line context.
- Update tox.ini to cover up to 3.14.

DISCLOSURE: Except for three simple commits (9f08253, 4d87df0, 3edcd84), the contributions were mainly written using ChatGPT Codex and then thoroughly reviewed.
